### PR TITLE
Fix the stop method in mp3plalayer.js

### DIFF
--- a/js/mp3-player.js
+++ b/js/mp3-player.js
@@ -38,8 +38,7 @@ class MP3Player {
     stop = () => {
         // If the sound promise is not null, then stop the audio
         this.audio.pause();
-        this.audio.currentTime = 0;
-        this.audio = null;
+        this.audio.currentTime = 0;        
     }
 
     pause = () => {


### PR DESCRIPTION
The stop method would set the playlist back to the beginning, instead of setting the song to the beginnning